### PR TITLE
Fix some errors and add new support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ fun TaskContainerScope.configureShadowJar() {
     shadowJar {
         archiveBaseName.set("Overwatcheat")
         archiveClassifier.set("")
-        archiveVersion.set("")
+        archiveVersion.set("${project.version}")
 
         isZip64 = true
     }
@@ -59,6 +59,7 @@ fun TaskContainerScope.configureShadowJar() {
 
 fun TaskContainerScope.configureOverwatcheat() {
     register("overwatcheat") {
+        dependsOn(shadowJar)
         doLast {
             val version = version
             val name = "Overwatcheat $version"

--- a/src/main/kotlin/org/jire/overwatcheat/framegrab/FrameGrabber.kt
+++ b/src/main/kotlin/org/jire/overwatcheat/framegrab/FrameGrabber.kt
@@ -29,7 +29,6 @@ class FrameGrabber(
     format: String = "gdigrab",
     filename: String = "title=${FrameWindowFinder.findWindowTitle(windowTitleSearch)}"
 ) : FFmpegFrameGrabber(filename) {
-
     init {
         this.frameRate = frameRate
         this.imageWidth = imageWidth
@@ -40,4 +39,15 @@ class FrameGrabber(
         setOption("offset_y", captureOffsetY.toString())
     }
 
+    /**
+     * Because javacv comment tryLoad() in the latest version,
+     * So we need to load it manually
+     *
+     * @see FFmpegFrameGrabber static block
+     */
+    companion object {
+        init {
+            tryLoad()
+        }
+    }
 }

--- a/src/main/kotlin/org/jire/overwatcheat/framegrab/FrameGrabber.kt
+++ b/src/main/kotlin/org/jire/overwatcheat/framegrab/FrameGrabber.kt
@@ -27,7 +27,7 @@ class FrameGrabber(
     imageHeight: Int,
     captureOffsetX: Int, captureOffsetY: Int,
     format: String = "gdigrab",
-    filename: String = "title=${FrameWindowFinder.findWindowTitle(windowTitleSearch)}"
+    filename: String = convertWindowName(windowTitleSearch)
 ) : FFmpegFrameGrabber(filename) {
     init {
         this.frameRate = frameRate
@@ -51,3 +51,9 @@ class FrameGrabber(
         }
     }
 }
+const val DESKTOP = "desktop"
+fun convertWindowName(windowTitle: String): String =
+    if (DESKTOP == windowTitle)
+        DESKTOP
+    else
+        "title=${FrameWindowFinder.findWindowTitle(windowTitle)}"


### PR DESCRIPTION
1. Since the latest version of javacv comment `tryLoad()`, So we need to load it manually.
2. Support FFmpeg "-i desktop"  
Usage: `window_title_search=desktop`

Edit:

3. Fix build failed