### PR TITLE
handling null frame exceptions

### DIFF
--- a/src/main/kotlin/org/jire/overwatcheat/framegrab/FrameGrabberThread.kt
+++ b/src/main/kotlin/org/jire/overwatcheat/framegrab/FrameGrabberThread.kt
@@ -31,7 +31,9 @@ class FrameGrabberThread(
         try {
             while (true) {
                 val frame = frameGrabber.grabImage()
-                frameHandler.handle(frame)
+                if (frame) {
+                    frameHandler.handle(frame)
+                }
             }
         } finally {
             frameGrabber.stop()


### PR DESCRIPTION
It crashes the thread if the framegrabber can't grab a frame? i don't know exactly why it can't grab but when it can't it crashes so this checks if there's some sort of frame insted of null